### PR TITLE
Upgrade dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,14 +5,14 @@ buildscript {
 
     dependencies {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.8'
-        classpath 'com.bmuschko:gradle-docker-plugin:4.3.0'
-        classpath 'io.franzbecker:gradle-lombok:2.0'
+        classpath 'com.bmuschko:gradle-docker-plugin:4.5.0'
+        classpath 'io.franzbecker:gradle-lombok:2.1'
     }
 }
 
 plugins {
-    id 'org.springframework.boot' version '2.1.2.RELEASE' apply false
-    id 'io.spring.dependency-management' version '1.0.6.RELEASE' apply false
+    id 'org.springframework.boot' version '2.1.3.RELEASE' apply false
+    id 'io.spring.dependency-management' version '1.0.7.RELEASE' apply false
     id 'org.sonarqube' version '2.7'
 }
 
@@ -50,21 +50,21 @@ subprojects {
 
     dependencyManagement {
         imports {
-            mavenBom 'org.springframework.boot:spring-boot-dependencies:2.1.2.RELEASE'
-            mavenBom 'com.linecorp.armeria:armeria-bom:0.79.0'
+            mavenBom 'org.springframework.boot:spring-boot-dependencies:2.1.3.RELEASE'
+            mavenBom 'com.linecorp.armeria:armeria-bom:0.80.0'
         }
 
         dependencies {
-            dependency 'io.reactivex.rxjava2:rxjava:2.2.6'
+            dependency 'io.reactivex.rxjava2:rxjava:2.2.7'
 
             dependency 'javax.annotation:javax.annotation-api:1.3.2'
 
             // Logging
             dependency 'ch.qos.logback:logback-classic:1.2.3'
-            dependency 'org.slf4j:log4j-over-slf4j:1.7.25'
+            dependency 'org.slf4j:log4j-over-slf4j:1.7.26'
 
             // Test
-            dependencySet(group:'org.junit.jupiter', version: '5.3.2') {
+            dependencySet(group:'org.junit.jupiter', version: '5.4.0') {
                 entry 'junit-jupiter-api'
                 entry 'junit-jupiter-engine'
             }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu Jan 17 17:49:20 KST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.google.protobuf'
 
 ext {
     protobufVersion = '3.6.1'
-    grpcVersion = '1.17.1'
+    grpcVersion = '1.19.0'
 
     generatedFilesBaseDir = "$projectDir/src/generated"
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -7,6 +7,8 @@ dependencies {
     implementation 'com.linecorp.armeria:armeria-spring-boot-webflux-starter'
     implementation 'com.linecorp.armeria:armeria-grpc'
 
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     implementation 'io.reactivex.rxjava2:rxjava'
 
     implementation 'com.hubspot.slack:slack-base'


### PR DESCRIPTION
Dependencies

- spring-boot-dependencies: 2.1.2.RELEASE -> 2.1.3.RELEASE
- armeria-bom: 0.79.0 -> 0.80.0
- rxjava: 2.2.6 -> 2.2.7
- io.grpc: 1.17.1 -> 1.19.0
- log4j-over-slf4j: 1.7.25 -> 1.7.26
- org.junit.jupiter: 5.3.2 -> 5.4.0

Gradle and its plugins

- Gradle: 5.1.1 -> 5.2.1
- org.springframework.boot: 2.1.2.RELEASE -> 2.1.3.RELEASE
- io.spring.dependency-management: 1.0.6.RELEASE -> 1.0.7.RELEASE
- gradle-docker-plugin: 4.3.0 -> 4.5.0
- gradle-lombok: 2.0 -> 2.1