### PR TITLE
Skip DataSource health check for a while

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -39,7 +39,11 @@ cloud:
     stack:
       auto: false
 
+
 management:
+  health:
+    db:
+      enabled: false
   metrics:
     export:
       cloudwatch:


### PR DESCRIPTION
```
{"timestamp":"2019-06-16 10:35:11.865","level":"WARN","thread":"elastic-2","logger":"org.springframework.boot.actuate.jdbc.DataSourceHealthIndicator","message":"DataSource health check failed","context":"default","exception":"org.springframework.jdbc.CannotGetJdbcConnectionException: Failed to obtain JDBC Connection; nested exception is java.sql.SQLException: HikariDataSource HikariDataSource (HikariPool-1) has been closed.
\tat org.springframework.jdbc.datasource.DataSourceUtils.getConnection(DataSourceUtils.java:81)
\tat org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:323)
\tat org.springframework.boot.actuate.jdbc.DataSourceHealthIndicator.getProduct(DataSourceHealthIndicator.java:122)
\tat org.springframework.boot.actuate.jdbc.DataSourceHealthIndicator.doDataSourceHealthCheck(DataSourceHealthIndicator.java:109)
\tat org.springframework.boot.actuate.jdbc.DataSourceHealthIndicator.doHealthCheck(DataSourceHealthIndicator.java:104)
\tat org.springframework.boot.actuate.health.AbstractHealthIndicator.health(AbstractHealthIndicator.java:84)
\tat org.springframework.boot.actuate.health.HealthIndicatorReactiveAdapter.invoke(HealthIndicatorReactiveAdapter.java:48)
\tat org.springframework.boot.actuate.health.HealthIndicatorReactiveAdapter.lambda$null$0(HealthIndicatorReactiveAdapter.java:43)
\tat reactor.core.scheduler.ElasticScheduler$DirectScheduleTask.run(ElasticScheduler.java:292)
\tat reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:50)
\tat reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:27)
\tat java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
\tat java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
\tat java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.sql.SQLException: HikariDataSource HikariDataSource (HikariPool-1) has been closed.
\tat com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:96)
\tat org.springframework.jdbc.datasource.DataSourceUtils.fetchConnection(DataSourceUtils.java:157)
\tat org.springframework.jdbc.datasource.DataSourceUtils.doGetConnection(DataSourceUtils.java:115)
\tat org.springframework.jdbc.datasource.DataSourceUtils.getConnection(DataSourceUtils.java:78)
\t... 15 common frames omitted
"}
```